### PR TITLE
bbs1-lg.de

### DIFF
--- a/lib/domains/de/bbs1-lg
+++ b/lib/domains/de/bbs1-lg
@@ -1,0 +1,1 @@
+Berufsbildenden Schulen I Lüneburg


### PR DESCRIPTION
This is the domain of our quite recently added "school cloud".

There is no known reference on the [front-facing site](http://bbs1-lueneburg.de/joomla/), mostly because it's rarely updated and the mail service is new. It does reference [the IT subjects](http://bbs1-lueneburg.de/joomla/index.php/it-berufe) though.

A signed version of the domain reg [is available however](https://gist.github.com/DamonGant/e8b64db8f3c4bbb9215368fd624528f5).

I'm sure if need be I can make them add a cross-reference.